### PR TITLE
Python2/3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.5
+  - 3.6
 install:
   - pip install tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: python
 python:
-  - "2.7"
+  - 2.7
+  - 3.5
 install:
   - pip install tox-travis
 script:

--- a/programmer/.gitignore
+++ b/programmer/.gitignore
@@ -1,6 +1,7 @@
 .cache
 .coverage
 .tox
+.pytest_cache
 __pycache__
 htmlcov
 build

--- a/programmer/test.py
+++ b/programmer/test.py
@@ -19,7 +19,7 @@ class FakeSerial(object):
         self.read_data = read_data
 
     def write(self, data):
-        assert isinstance(data, bytes)
+        assert isinstance(data, bytearray)
         self.written.append(data)
 
     def read(self, read_len):
@@ -35,7 +35,7 @@ class FakeSerial(object):
         # insert True after each write (for flush calls)
         expected = []
         for part in parts:
-            expected.append(str(part))
+            expected.append(part)
             expected.append(True)
         # test
         assert self.written == expected

--- a/programmer/test.py
+++ b/programmer/test.py
@@ -35,7 +35,7 @@ class FakeSerial(object):
         # insert True after each write (for flush calls)
         expected = []
         for part in parts:
-            expected.append(part)
+            expected.append(str(part))
             expected.append(True)
         # test
         assert self.written == expected
@@ -50,7 +50,8 @@ def bitstream_dir():
 6f 77 6e 66 6f 78 6a 75 6d 70 73 6f 76 65 72 74 68 65 6c 61 7a 79 64
 6f 67
     '''.strip() + '\n\n'
-    assert bytes.fromhex(hexdata.replace(' ', '').replace('\n', '')) == DATA
+    data = bytearray.fromhex(hexdata.replace(' ', '').replace('\n', ''))
+    assert data == DATA
     # create temporary directory
     tmpdir = tempfile.mkdtemp()
     # create the files
@@ -77,16 +78,16 @@ def bitstream_dir():
 ])
 def test_simple_cmds(method, serial_out, serial_in, expected):
     # prepare
-    serial = FakeSerial(bytes.fromhex(serial_in))
+    serial = FakeSerial(bytearray.fromhex(serial_in))
     fpga = TinyFPGAB(serial)
     if expected is not None:
-        expected = bytes.fromhex(expected)
+        expected = bytearray.fromhex(expected)
     # run
     output = getattr(fpga, method)()
     # check
     assert output == expected
     assert not serial.read_data
-    serial.assert_written([bytes.fromhex(serial_out)])
+    serial.assert_written([bytearray.fromhex(serial_out)])
 
 
 @pytest.mark.parametrize('success_after', range(5))
@@ -131,18 +132,18 @@ def test_read(length, serial_outs):
     # check
     assert output == DATA[:length]
     assert not serial.read_data
-    serial.assert_written([bytes.fromhex(d) for d in serial_outs])
+    serial.assert_written([bytearray.fromhex(d) for d in serial_outs])
 
 
 def test_wait_while_busy():
     # prepare
-    serial = FakeSerial(bytes.fromhex('0101010100'))
+    serial = FakeSerial(bytearray.fromhex('0101010100'))
     fpga = TinyFPGAB(serial)
     # run
     assert fpga.wait_while_busy() is None
     # check
     assert not serial.read_data
-    serial.assert_written([bytes.fromhex('010100020005')] * 5)
+    serial.assert_written([bytearray.fromhex('010100020005')] * 5)
 
 
 @pytest.mark.parametrize('offset, length, block_len, serial_outs', [
@@ -186,7 +187,7 @@ def test_erase(offset, length, block_len, serial_outs):
     assert fpga.erase(offset, length) is None
     # check
     assert not serial.read_data
-    serial.assert_written([bytes.fromhex(d) for d in serial_outs])
+    serial.assert_written([bytearray.fromhex(d) for d in serial_outs])
     expected_calls = []
     restore_first_block = None
     if offset % block_len > 0:  # restore start of first block
@@ -235,9 +236,7 @@ def test_write(offset, length, serial_outs):
     assert fpga.write(offset, data) is None
     # check
     assert not serial.read_data
-    prueba = [bytes.fromhex(d) for d in serial_outs]
-    print("Creado: {}".format(prueba))
-    serial.assert_written(prueba)
+    serial.assert_written([bytearray.fromhex(d) for d in serial_outs])
 
 
 @pytest.mark.parametrize('success', [True, False])

--- a/programmer/tinyfpgab/__init__.py
+++ b/programmer/tinyfpgab/__init__.py
@@ -31,10 +31,10 @@ class TinyFPGAB(object):
         assert isinstance(data, bytes)
         cmd_read_len = read_len + 1 if read_len else 0
         addr = b'' if addr is None else struct.pack('>I', addr)[1:]
-        write_string = bytes([opcode]) + addr + data
+        write_string = bytearray([opcode]) + addr + data
         cmd_write_string = b'\x01' + struct.pack(
             '<HH', len(write_string), cmd_read_len) + write_string
-        self.ser.write(cmd_write_string)
+        self.ser.write(bytearray(cmd_write_string))
         self.ser.flush()
         return self.ser.read(read_len)
 
@@ -220,7 +220,7 @@ class TinyFPGAB(object):
             return True
 
     def boot(self):
-        self.ser.write(b"\x00")
+        self.ser.write(bytearray([0x00]))
         self.ser.flush()
 
     def slurp(self, filename):

--- a/programmer/tox.ini
+++ b/programmer/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py36
+envlist =
+    py27
+    py35
 
 [testenv]
 deps =
@@ -9,4 +11,3 @@ deps =
     pytest-cov
 commands=
     py.test --pep8 --cov --cov-report term-missing tinyfpgab test.py
-    py36: coverage html

--- a/programmer/tox.ini
+++ b/programmer/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 envlist =
     py27
-    py35
+    py36
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR adds compatibility to both Python 2.7 and 3.5 versions to the branch `python3` :smile: 

NOTE: this should be tested also with a real TyniFPGA B board.